### PR TITLE
Added license field

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
     "type": "git",
     "url": "https://github.com/deanm/css-color-parser-js"
   },
-  "license": "ISC",
+  "license": "MIT",
   "main": "csscolorparser.js"
 }

--- a/package.json
+++ b/package.json
@@ -7,5 +7,6 @@
     "type": "git",
     "url": "https://github.com/deanm/css-color-parser-js"
   },
+  "license": "ISC",
   "main": "csscolorparser.js"
 }


### PR DESCRIPTION
In trying to package your library for use with webjars (http://www.webjars.org/npm), I ran into a problem whereby it requires the 'license' field be set. It seems you're using the ISC license, so I've added the appropriate field. 