### PR TITLE
Add support for CSS Color Module Level 4

### DIFF
--- a/csscolorparser.js
+++ b/csscolorparser.js
@@ -82,6 +82,7 @@ var kCSSColorTable = {
   "peachpuff": [255,218,185,1], "peru": [205,133,63,1],
   "pink": [255,192,203,1], "plum": [221,160,221,1],
   "powderblue": [176,224,230,1], "purple": [128,0,128,1],
+  "rebeccapurple": [102,51,153,1],
   "red": [255,0,0,1], "rosybrown": [188,143,143,1],
   "royalblue": [65,105,225,1], "saddlebrown": [139,69,19,1],
   "salmon": [250,128,114,1], "sandybrown": [244,164,96,1],


### PR DESCRIPTION
Support `rebeccapurple`, the only new color added in [CSS Color Module Level 4](https://drafts.csswg.org/css-color/#named-colors). It has been supported by all major browser vendors for about two years - since Chrome 38 (current: 52), Firefox 33 (current 48), IE 11 (current: Edge 14), and Safari 7.1 (current: 9.1), so this is hardly experimental or outside the spec.
