### PR TITLE
Accept #rgba and #rrggbbaa notation

### DIFF
--- a/csscolorparser.js
+++ b/csscolorparser.js
@@ -163,10 +163,10 @@ function parseCSSColor(css_str) {
     } else if (str.length === 9) {
       // #rrggbbaa
       if (!(iv >= 0 && iv <= 0xffffffff)) return null;  // Covers NaN.
-      return [(iv & 0xff000000) >> 24,
-              (iv & 0x00ff0000) >> 16,
-              (iv & 0x0000ff00) >> 8,
-              (iv & 0x000000ff) / 256];
+      return [((iv & 0xff000000) >> 24) & 0xff,
+               (iv & 0x00ff0000) >> 16,
+               (iv & 0x0000ff00) >> 8,
+               (iv & 0x000000ff) / 256];
     }
 
     return null;

--- a/csscolorparser.js
+++ b/csscolorparser.js
@@ -159,14 +159,14 @@ function parseCSSColor(css_str) {
       return [((iv & 0xf000) >> 8) | ((iv & 0xf000) >> 12),
               ((iv & 0x0f00) >> 4) | ((iv & 0x0f00) >> 8),
                (iv & 0x00f0)       | ((iv & 0x00f0) >> 4),
-              ((iv & 0x000f) << 4  |  (iv & 0x000f)) / 256];
+              ((iv & 0x000f) << 4  |  (iv & 0x000f)) / 255];
     } else if (str.length === 9) {
       // #rrggbbaa
       if (!(iv >= 0 && iv <= 0xffffffff)) return null;  // Covers NaN.
       return [((iv & 0xff000000) >> 24) & 0xff,
                (iv & 0x00ff0000) >> 16,
                (iv & 0x0000ff00) >> 8,
-               (iv & 0x000000ff) / 256];
+               (iv & 0x000000ff) / 255];
     }
 
     return null;

--- a/csscolorparser.js
+++ b/csscolorparser.js
@@ -138,20 +138,35 @@ function parseCSSColor(css_str) {
 
   // #abc and #abc123 syntax.
   if (str[0] === '#') {
+    var iv = parseInt(str.substr(1), 16);  // TODO(deanm): Stricter parsing.
     if (str.length === 4) {
-      var iv = parseInt(str.substr(1), 16);  // TODO(deanm): Stricter parsing.
+      // #rgb
       if (!(iv >= 0 && iv <= 0xfff)) return null;  // Covers NaN.
       return [((iv & 0xf00) >> 4) | ((iv & 0xf00) >> 8),
-              (iv & 0xf0) | ((iv & 0xf0) >> 4),
-              (iv & 0xf) | ((iv & 0xf) << 4),
+               (iv & 0x0f0)       | ((iv & 0x0f0) >> 4),
+              ((iv & 0x00f) << 4) |  (iv & 0x00f),
               1];
     } else if (str.length === 7) {
-      var iv = parseInt(str.substr(1), 16);  // TODO(deanm): Stricter parsing.
+      // #rrggbb
       if (!(iv >= 0 && iv <= 0xffffff)) return null;  // Covers NaN.
       return [(iv & 0xff0000) >> 16,
-              (iv & 0xff00) >> 8,
-              iv & 0xff,
+              (iv & 0x00ff00) >> 8,
+               iv & 0x0000ff,
               1];
+    } else if (str.length === 5) {
+      // #rgba
+      if (!(iv >= 0 && iv <= 0xffff)) return null;  // Covers NaN.
+      return [((iv & 0xf000) >> 8) | ((iv & 0xf000) >> 12),
+              ((iv & 0x0f00) >> 4) | ((iv & 0x0f00) >> 8),
+               (iv & 0x00f0)       | ((iv & 0x00f0) >> 4),
+              ((iv & 0x000f) << 4  |  (iv & 0x000f)) / 256];
+    } else if (str.length === 9) {
+      // #rrggbbaa
+      if (!(iv >= 0 && iv <= 0xffffffff)) return null;  // Covers NaN.
+      return [(iv & 0xff000000) >> 24,
+              (iv & 0x00ff0000) >> 16,
+              (iv & 0x0000ff00) >> 8,
+              (iv & 0x000000ff) / 256];
     }
 
     return null;


### PR DESCRIPTION
Add parsing for the `#rgba` and `#rrggbbaa` notations.

These notations are specified in the CSS Color Module Level 4 specs (https://drafts.csswg.org/css-color/#hex-notation) , and supported by current browsers as per Chrome 52 https://www.chromestatus.com/feature/5685348285808640 , Firefox 49 https://bugzilla.mozilla.org/show_bug.cgi?id=567283 and Safari 9.1.

I added some spaces and leading zeroes around, just to improve the readability a bit and to make better sense of the bit-wise logic. I can remove those if you ask.